### PR TITLE
Fix Lua error in `/buffet bests`

### DIFF
--- a/Buffet.lua
+++ b/Buffet.lua
@@ -830,8 +830,7 @@ function Core:SlashHandler(message, editbox)
         end
     elseif cmd == "bests" then
         Utility.Print("Best item ids:")
-        local bests = table.sort(Core:BestsBeautifier())
-        for k,v in pairs(bests) do
+        for k,v in pairs(Core:BestsBeautifier()) do
             Utility.Print("bests."  .. k .. "=" .. v)
         end
 --@debug@


### PR DESCRIPTION
`table.sort` doesn't return, causing an error when you try and iterate over `nil`, and it doesn't really sort a key/value list in a useful way without a userland function, so I've just removed it.