### PR TITLE
Prefer restricted items over common items in restricted areas

### DIFF
--- a/Buffet.lua
+++ b/Buffet.lua
@@ -383,14 +383,16 @@ function Core:Scan()
 
                     -- set bests
                     local healthCats, manaCats = Engine.GetCategories(itemData)
+                    local hasRestriction = Engine.HasRestriction(itemId)
+
                     if healthCats then
                         for _, v2 in pairs(healthCats) do
-                            self:SetBest(v2, itemId, health, itemCount)
+                            self:SetBest(v2, itemId, health, itemCount, hasRestriction)
                         end
                     end
                     if manaCats then
                         for _, v2 in pairs(manaCats) do
-                            self:SetBest(v2, itemId, mana, itemCount)
+                            self:SetBest(v2, itemId, mana, itemCount, hasRestriction)
                         end
                     end
                 end
@@ -707,11 +709,14 @@ function Core:EditConsumable(name, substring, conjured, pot, mod)
     EditMacro(macroid, name, "INV_Misc_QuestionMark", substring:gsub("%%MACRO%%", cast), 1)
 end
 
-function Core:SetBest(cat, id, value, stack)
-    -- Utility.Debug("SetBest: ", cat, id, value, stack)
+function Core:SetBest(cat, id, value, stack, hasRestriction)
     local best = Core.bests[cat];
     if best and id then
-        if (value > best.val) or ((value == best.val) and (best.stack > stack)) then
+        -- Utility.Debug("SetBest: ", cat, id, value, stack, " vs ", best.val, best.stack, ", has restriction:", hasRestriction)
+        if (value > best.val -- straight better value
+            or ((value == best.val) and (best.stack > stack)) -- less of these items than the current best item
+            or (value == best.val and hasRestriction)) -- new item has a restriction that is currently met
+        then
             best.val = value
             best.id = id
             best.stack = stack

--- a/Classic/Classic.lua
+++ b/Classic/Classic.lua
@@ -71,10 +71,14 @@ if Utility.IsClassic then
         return itemData
     end
 
+    function Engine.HasRestriction(itemId)
+        return ConstClassic.Restrictions[itemId] ~= nil
+    end
+
     -- return true if the item is restricted, false otherwise
     function Engine.CheckRestriction(itemId)
         -- check restricted items against rules
-        if ConstClassic.Restrictions[itemId] ~= nil then
+        if Engine.HasRestriction(itemId) then
             for _, entry in pairs(ConstClassic.Restrictions[itemId]) do
                 local valid = Engine.CheckRestrictionEntry(entry)
                 if valid then

--- a/Retail/Retail.lua
+++ b/Retail/Retail.lua
@@ -57,10 +57,14 @@ if Utility.IsRetail then
         return itemData
     end
 
+    function Engine.HasRestriction(itemId)
+        return ConstRetail.Restrictions[itemId] ~= nil
+    end
+
     -- return true if the item is restricted, false otherwise
     function Engine.CheckRestriction(itemId)
         -- check restricted items against rules
-        if ConstRetail.Restrictions[itemId] ~= nil then
+        if Engine.HasRestriction(itemId) then
             for _, entry in pairs(ConstRetail.Restrictions[itemId]) do
                 local valid = Engine.CheckRestrictionEntry(entry)
                 if valid then

--- a/TBC/TBC.lua
+++ b/TBC/TBC.lua
@@ -58,10 +58,14 @@ if Utility.IsTBC then
         return itemData
     end
 
+    function Engine.HasRestriction(itemId)
+        return ConstTBC.Restrictions[itemId] ~= nil
+    end
+
     -- return true if the item is restricted, false otherwise
     function Engine.CheckRestriction(itemId)
         -- check restricted items against rules
-        if ConstTBC.Restrictions[itemId] ~= nil then
+        if Engine.HasRestriction(itemId) then
             for _, entry in pairs(ConstTBC.Restrictions[itemId]) do
                 local valid = Engine.CheckRestrictionEntry(entry)
                 if valid then


### PR DESCRIPTION
This came up in the TK instances when I wanted Bottled Nethergon Energy to take precedence over my normal Super Mana Potions - they both have the same mana values, but the default iteration was causing the mana potions to take precedence when building the bests list. This change breaks a tie between the same values by giving precedence to an item that is usually restricted but isn't at the moment, indicating that you're, say, inside an instance where you can use the item.

I can also add an option to the options panel to control this behavior if you don't want it to be the default.